### PR TITLE
Chat command support and list players command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 /*.iml
 /*.ipr
 /*.iws
+*.iml
+
+*.hprof

--- a/src/main/java/net/shadowfacts/discordchat/DCConfig.java
+++ b/src/main/java/net/shadowfacts/discordchat/DCConfig.java
@@ -50,11 +50,17 @@ public class DCConfig {
 	@Config.Prop(category = "discord", description = "The token used to identify your bot to Discord.\nRequired")
 	public static String botToken = "";
 
+	@Config.Prop(category = "discord", description = "Your bot's ID.\nRequired")
+	public static String botId = "";
+
 	@Config.Prop(category = "discord", description = "The server ID to connect to.")
 	public static String serverId = "";
 
 	@Config.Prop(category = "discord", description = "Channels that should be forwarded to MC/MC be forwarded to.\n(Without the # at the beginning)")
 	public static String[] channels = new String[0];
+
+	@Config.Prop(description = "Prefix for chat commands")
+	public static char chatCommandPrefix = '!';
 
 	public static void init(File configDir) {
 		config = new Configuration(new File(configDir, "shadowfacts/DiscordChat.cfg"));
@@ -67,7 +73,7 @@ public class DCConfig {
 
 		if (config.hasChanged()) config.save();
 
-		if (botToken.isEmpty() || serverId.isEmpty() || Arrays.equals(channels, new String[0])) {
+		if (botToken.isEmpty() || botId.isEmpty() || serverId.isEmpty() || Arrays.equals(channels, new String[0])) {
 			DiscordChat.log.warn("Missing required information, disabling DiscordChat");
 			DiscordChat.log.warn("Please go to config/shadowfacts/DiscordChat.cfg and fill out the required fields and restart Minecraft to enable DiscordChat");
 			enabled = false;

--- a/src/main/java/net/shadowfacts/discordchat/commands/ChatCommands.java
+++ b/src/main/java/net/shadowfacts/discordchat/commands/ChatCommands.java
@@ -1,0 +1,33 @@
+package net.shadowfacts.discordchat.commands;
+
+import net.dv8tion.jda.entities.User;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.fml.common.FMLCommonHandler;
+import net.shadowfacts.discordchat.discord.DiscordThread;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Naosyth
+ */
+public class ChatCommands {
+	public boolean cconline(User sender, String args) {
+		List<EntityPlayerMP> players = FMLCommonHandler.instance().getMinecraftServerInstance().getServer().getPlayerList().getPlayerList();
+		int numPlayers = players.size();
+
+		if (numPlayers == 0) {
+			DiscordThread.instance.sendMessageToAllChannels("No players are currently online.");
+			return true;
+		}
+
+		List<String> names = new ArrayList<String>();
+		for (EntityPlayerMP player : players) {
+			names.add(player.getName());
+		}
+		String nameStrings = String.join(", ", names);
+		DiscordThread.instance.sendMessageToAllChannels("There " + (numPlayers == 1 ? "is" : "are") + " currently **" + numPlayers + "** player" + (numPlayers == 1 ? "" : "s") + " online:");
+		DiscordThread.instance.sendMessageToAllChannels(nameStrings);
+		return true;
+	}
+}

--- a/src/main/java/net/shadowfacts/discordchat/discord/MainListener.java
+++ b/src/main/java/net/shadowfacts/discordchat/discord/MainListener.java
@@ -4,6 +4,7 @@ import net.dv8tion.jda.events.message.guild.GuildMessageReceivedEvent;
 import net.dv8tion.jda.hooks.ListenerAdapter;
 import net.shadowfacts.discordchat.DCConfig;
 import net.shadowfacts.discordchat.utils.MiscUtils;
+import net.shadowfacts.discordchat.utils.CommandUtils;
 
 /**
  * @author shadowfacts
@@ -12,9 +13,16 @@ public class MainListener extends ListenerAdapter {
 
 	@Override
 	public void onGuildMessageReceived(GuildMessageReceivedEvent event) {
-		if (MiscUtils.shouldUseChannel(event.getChannel()) && event.getGuild().getId().equals(DCConfig.serverId) && !MiscUtils.isMessageFromMC(event.getMessage())) {
+		if (shouldForwardMessage(event)) {
 			MiscUtils.sendMessage(MiscUtils.fromDiscordMessage(event.getMessage()));
 		}
+	}
+
+	private boolean shouldForwardMessage(GuildMessageReceivedEvent event) {
+		return (MiscUtils.shouldUseChannel(event.getChannel()) &&
+						event.getGuild().getId().equals(DCConfig.serverId) &&
+						!MiscUtils.isMessageFromMC(event.getMessage()) &&
+						!CommandUtils.processCommand(event));
 	}
 
 }

--- a/src/main/java/net/shadowfacts/discordchat/utils/CommandUtils.java
+++ b/src/main/java/net/shadowfacts/discordchat/utils/CommandUtils.java
@@ -1,0 +1,37 @@
+package net.shadowfacts.discordchat.utils;
+
+import net.dv8tion.jda.entities.User;
+import net.dv8tion.jda.events.message.guild.GuildMessageReceivedEvent;
+import net.shadowfacts.discordchat.DCConfig;
+import net.shadowfacts.discordchat.commands.ChatCommands;
+
+import java.lang.reflect.*;
+
+/**
+ * @author Naosyth
+ */
+public class CommandUtils {
+	public static boolean processCommand(GuildMessageReceivedEvent event) {
+		String message = event.getMessage().getContent().trim();
+
+		if (message.charAt(0) != DCConfig.chatCommandPrefix) {
+			return false;
+		}
+
+		String[] components = message.split(" ", 2);
+		String command = components[0].substring(1).toLowerCase();
+
+		String args = "";
+		if (components.length > 1) {
+			args = components[1];
+		}
+
+		ChatCommands chatCommands = new ChatCommands();
+		Class<?>[] paramTypes = { User.class, String.class };
+		try {
+			Method m = ChatCommands.class.getDeclaredMethod("cc" + command, paramTypes);
+			return (Boolean)m.invoke(chatCommands, event.getAuthor(), args);
+		}
+		catch (Exception e) { return false; }
+	}
+}

--- a/src/main/java/net/shadowfacts/discordchat/utils/MiscUtils.java
+++ b/src/main/java/net/shadowfacts/discordchat/utils/MiscUtils.java
@@ -12,6 +12,8 @@ import net.shadowfacts.discordchat.DCConfig;
 
 import java.util.regex.Pattern;
 
+import static net.shadowfacts.discordchat.DCConfig.botId;
+
 /**
  * @author shadowfacts
  */
@@ -46,11 +48,7 @@ public class MiscUtils {
 	}
 
 	public static boolean isMessageFromMC(Message message) {
-		return isMessageFromMC(message.getContent());
-	}
-
-	public static boolean isMessageFromMC(String message) {
-		return discordMessage.matcher(message).matches() || isDeathMessage(message) || isAchievementMessage(message) || isPlayerJoinMessage(message) || isPlayerLeaveMessage(message);
+		return message.getAuthor().getId().equals(botId);
 	}
 
 	private static boolean isDeathMessage(String message) {


### PR DESCRIPTION
Adds support for chat commands to the bot

Added 2 new config values: chat command prefix and bot ID

Bot ID is used to check if Discord messages are coming from the Discord bot. If they are, then it doesn't get broadcast in-game. This replaces the old pattern matching method, since pattern matching for the command (and all future commands) could get unwieldy pretty fast.

The only command I added here is `!online` which lists all online players. Future commands come include admin stuff, server uptime, tick rate, etc.

Edit: I just saw that other guy's chat command PR. I kinda like his command registry implementation better, so yeah... Do whatever you want with this PR. 
