### PR TITLE
Unhandled exception in log file when missing message write permission

### DIFF
--- a/core/src/main/java/net/shadowfacts/discordchat/core/DiscordChat.java
+++ b/core/src/main/java/net/shadowfacts/discordchat/core/DiscordChat.java
@@ -159,6 +159,8 @@ public class DiscordChat implements IDiscordChat {
 				}
 			} catch (ErrorResponseException e) {
 				logger.error(e, "Error sending message to Discord: " + e.getErrorResponse().getCode() + " (" + e.getErrorResponse().getMeaning() + ")");
+			} catch (InsufficientPermissionException e) {
+				logger.error(e, "Error sending message to Discord: " + e.getMessage());
 			}
 		}
 	}


### PR DESCRIPTION
I wrote up the issue in #136 and added details there.

Unhandled exceptions have caused me much frustration IRL, so I wanted to at least catch this one and keep it from messing up the environment for other mods.

This PR contains an additional catch statement for the InsufficientPermissionException coming out of the dv8tion library. It doesn't seem like there is anything else that can be done if the bot doesn't have permission, so instead, I have sent the error message into the error logger.